### PR TITLE
Reimplementação do script execução de testes no Runscope

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,168 +1,340 @@
-const async = require('async');
-const request = require('request');
+const axios = require('axios').default;
+const columnify = require('columnify');
 
-let args = process.argv;
-let environment = '';
-let testsIds = [];
-let key = '';
-let readingTests = false;
+const MAXIMUM_TESTS_PER_BATCH = 10;
+const MINIMUM_INTERVAL_BETWEEN_BATCH_EXECUTION_IN_MS = (10 * 1000);
+const INTERVAL_BETWEEN_TEST_VERIFICATIONS_IN_MS = (10 * 1000);
+const INTERVAL_BETWEEN_FETCH_TESTS_IDS_FROM_RUNSCOPE_IN_MS = (2 * 1000);
 
-// Armazena cada verificação de URL para respeitar um limite de novas tentativas.
-const verificationCounter = new Map();
+let bucketKey = '';
+let environmentId = '';
+let runscopeApiKey = '';
 
-// Carrega os argumentos
-for (let i = 2; i < args.length; i++) {
-    if(args[i] === '-env') {
-        ++i;
+let finishedTestIds = [];
+let finishedTestResults = {};
+let testNames = {};
+let readingTestsFromArgs = false;
+let fromArgsTestIds = [];
 
-        if(i >= args.length) {
-            throw Error("Environment inválido, utilize -env ENVIRONMENT");
+(async () => {
+    parseArguments();
+    validateArguments();
+
+    const environmentData = await fetchEnvironmentData();
+    printSharedEnvironmentVariables(environmentData.initialTestVariables);
+
+    let testsIds;
+    if(readingTestsFromArgs) {
+        testsIds = fromArgsTestIds;
+        console.log('Test list source: Argument list in -tests.');
+    }
+    else {
+        testsIds = await fetchTestListFronRunscope();
+        console.log('Test list source: Runscope API Test List.');
+    }
+
+    console.log(`\nTriggering execution of ${testsIds.length} tests in environment: ${environmentData.environmentName}`);
+
+    const runningTestIds = await runTestsInBatches(testsIds, MAXIMUM_TESTS_PER_BATCH);
+    startVerificationOnTests(runningTestIds);
+})();
+
+async function fetchTestListFronRunscope() {
+    console.log(`Starting to fetch test list from Runscope API.`);
+    const triggerUrlRegex = /https:\/\/api\.runscope\.com\/radar\/([0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{12})\/trigger/;
+    let testList = [];
+    let runnableTestsCount = 0;
+    let ignoredTestsCount = 0;
+    let noRemainingTestsToFetch = false;
+    let nextOffsetToFetch = 0;
+    while(noRemainingTestsToFetch == false) {
+        const testListResponse = await axios.get(`https://api.runscope.com/buckets/${bucketKey}/tests?offset=${nextOffsetToFetch}`, {
+            headers: {
+                'Authorization': `Bearer ${runscopeApiKey}`
+            }
+        });
+        const partialTestList = testListResponse.data.data;
+        for(let test of partialTestList) {
+            let regexMatches = triggerUrlRegex.exec(test.trigger_url);
+            if(regexMatches == null)
+                throw Error(`Error extracting trigger ID from URL: ${test.trigger_url}`);
+            const testId = regexMatches[1];
+
+            // Ignore tests with [IGNORED] prefix in name
+            if(test.name.startsWith(`[IGNORED]`)) {
+                ignoredTestsCount ++;
+                console.log(`⚠ Test ignored, name: ${test.name}, testId; ${testId}`);
+                continue;
+            }
+
+            runnableTestsCount ++;
+            testList.push(testId);
         }
+        if(partialTestList.length == 0)
+            noRemainingTestsToFetch = true;
+        else
+            nextOffsetToFetch += partialTestList.length;
+        await sleep(INTERVAL_BETWEEN_FETCH_TESTS_IDS_FROM_RUNSCOPE_IN_MS);
+    }
+    console.log(`Test list fetched, total: ${runnableTestsCount + ignoredTestsCount}, runnable: ${runnableTestsCount}, ignored: ${ignoredTestsCount}`);
+    return testList;    
+}
 
-        environment = args[i];
-    } else if (args[i] === '-key') {
-        ++i;
+function parseArguments() {
+    const INITIAL_ARG_INDEX = 2;
 
-        if(i >= args.length) {
-            throw Error("Key inválida, utilize -key KEY");
+    let args = process.argv;
+    let runscopeKeyArgumentFound = false;
+    let bucketArgumentFound = false;
+    let environmentArgumentFound = false;
+
+    for (let i = INITIAL_ARG_INDEX; i < args.length; i++) {
+        if (args[i] === '-key') {
+            ++i;
+    
+            if(i >= args.length) {
+                throw Error('Missing Runscope API Key, use: -key RUNSCOPE_API_KEY');
+            }
+            runscopeApiKey = args[i].trim();
+            runscopeKeyArgumentFound = true;
+        } else if(args[i] === '-bucket') {
+            ++i
+
+            if(i>= args.lenth) {
+                throw Error('Missing Bucket Key, use -bucket BUCKET_KEY');
+            }
+            bucketKey = args[i].trim();
+            bucketArgumentFound = true;
+        } else if(args[i] === '-env') {
+            ++i;
+    
+            if(i >= args.length) {
+                throw Error('Missing Environment ID, use -env ENVIRONMENT_ID');
+            }
+            environmentId = args[i].trim();
+            environmentArgumentFound = true;
+        } else if (args[i] === '-tests') {
+            readingTestsFromArgs = true;
+        } else if (readingTestsFromArgs) {
+            fromArgsTestIds.push(args[i]);
         }
+    }
 
-        key = args[i];
-    } else if (args[i] === '-tests') {
-        readingTests = true;
-    } else if (readingTests) {
-        testsIds.push(args[i]);
+    if(!(runscopeKeyArgumentFound && bucketArgumentFound && environmentArgumentFound)) {
+        throw Error('Missing args, use: -key RUNSCOPE_API_KEY -bucket BUCKET_KEY -env ENVIRONMENT_ID');
     }
 }
 
-// Verificação simples
-if(key == '') {
-    throw Error("Key inválida, utilize -key KEY");
+function validateArguments() {
+    const runscopeIdsRegex = /^[0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{12}$/;
+    const bucketKeyRegex = /^[0-9a-z]{12}$/;
+
+    if(!runscopeIdsRegex.test(runscopeApiKey))
+        throw Error('Invalid Runscope API Key, use: -key YOUR_RUNSCOPE_API_KEY');
+
+    if(!bucketKeyRegex.test(bucketKey))
+        throw Error('Invalid Bucket Key, use: -bucket YOUR_BUCKET_KEY')
+    
+    if(!runscopeIdsRegex.test(environmentId))
+        throw Error('Invalid Environment, use: -env YOUR_ENVIRONMENT_ID');
+
+    for(let testId of fromArgsTestIds) {
+        if(!runscopeIdsRegex.test(testId))
+            throw Error('Invalid testId, use: -tests TEST_ID1 TEST_ID2 TEST_ID3 ...');
+    }
 }
 
-if(environment == '') {
-    console.log("Enviando os testes pelo ambiente padrão");
-}
-
-if(testsIds.length == 0) {
-    throw Error("Testes inválidos, utilize -tests TEST_ID_1 TEST_ID_2 TEST_ID_3...");
-}
-
-// Array de funções para chamar o request iniciais dos testes
-let requestFunctions = [];
-
-// Itera pelos testes enviados por argumento criando novas funções de request
-for (let i = 0; i < testsIds.length; i++) {
-    // Coloca na array a função de request
-    requestFunctions.push((callback) => {
-        request({
-            url: "https://api.runscope.com/radar/"+testsIds[i]+"/trigger?runscope_environment=" + environment,
-            method: "POST",
+async function fetchEnvironmentData() {
+    return new Promise((resolve, reject) => {
+        let initialTestVariables = undefined;
+        axios.get(`https://api.runscope.com/buckets/${bucketKey}/environments/${environmentId}`, {
             headers: {
-                "Content-Type": "application/json",
-                "Accept": "application/json",
-                "Authorization": 'Bearer ' + key
+                'Authorization': `Bearer ${runscopeApiKey}`
             }
-        }, async (error, response, body) => {
-            if (!error && response.statusCode === 201) { // HTTP Status 201 - CREATED
-                let result = await status(body);
-                callback(null, result);
-            } else {
-                callback(error, null);
-            }
+        }).then((response) => {
+            environmentName = response.data.data.name;
+            initialTestVariables = response.data.data['initial_variables'];
+            resolve({environmentName, initialTestVariables});
+        }).catch((reason) => {
+            if(reason.response.status == 404)
+                throw Error(`Invalid environment, Environment ID: ${environmentId}`);
+            throw Error(`An unexpected error occurred when fetching data for Environment: ${environmentId}, statusCode: ${reason.response.status}`);
         });
     });
 }
 
-// Verifica o teste recursivamente (por timeout)
-function verifyTest(test_url) {
-    console.log('Verificando ' + test_url);
+function printSharedEnvironmentVariables(initialEnvironmentVariables) {
+    const validEnvironmentVariables = arrayMapToObject(initialEnvironmentVariables, value => {
+        return value != '';
+    });
 
-    request({
-        url: test_url,
-        method: "GET",
-        headers: {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-            "Authorization": 'Bearer ' + key
+    const environmentVariablesCount = Object.keys(validEnvironmentVariables).length;
+    console.log(`\nFound ${environmentVariablesCount} Shared environment variables.`);
+
+    let lineCounter = 0;
+
+    const printColumns = columnify(validEnvironmentVariables, {
+        columns: ['ENVIRONTMENT VARIABLE', 'VALUE'],
+    }).split('\n').map(value => {
+        lineCounter ++;
+        if(lineCounter == 1)
+            return `            ${value}\n`;
+        return `            ${value}`;
+    });
+
+    console.log(printColumns.join('\n') + '\n');
+}
+
+async function runTestsInBatches(testsIds, maximumTestsPerBatch) {
+    const runningTestIds = [];
+
+    let batchList = splitArrayInPages(testsIds, maximumTestsPerBatch);
+    console.log(`Tests will be triggered in ${batchList.length} batches with a maximum of ${maximumTestsPerBatch} tests per batch.`);
+
+    for(let [batchIndex, batch] of batchList.entries()) {
+        const batchStartTimestamp = Date.now();
+        console.log(`Batch ${batchIndex + 1}/${batchList.length} with ${batch.length} tests.`);
+        let pendingTestPromises = [];
+        for(let testId of batch) {
+            const testTriggerPromise = triggerTest(testId);
+            testTriggerPromise.then((testTriggerResult) => {
+                runningTestIds.push({testId, triggeredTestId: testTriggerResult.triggeredTestId, testRunId: testTriggerResult.testRunId});
+                testNames[testId] = testTriggerResult.testName;
+                console.log(`   └────── Test triggered, testName: ${testTriggerResult.testName}, testId: ${testId}`);
+            });
+            pendingTestPromises.push(testTriggerPromise);
         }
-    }, function (error, res, body) {
-        if (!error && res.statusCode == 200) {
-            let result = JSON.parse(body);
 
-            let running = (result.data.finished_at == null);
-            if (running) {
-                setTimeout(function() {
-                    verifyTest(test_url);
-                }, 5000);
-            } else {
-                console.log('Result ' + body);
+        await Promise.all(pendingTestPromises).catch(() => { /* Just ignore these errors */ });
+        const batchDuration = Date.now() - batchStartTimestamp;
+        const timeToWaitToExecuteNextBatch = MINIMUM_INTERVAL_BETWEEN_BATCH_EXECUTION_IN_MS - batchDuration;
+        console.log(`   └────── Batch finished in ${Date.now() - batchStartTimestamp}ms`);
+        
+        if(batchIndex != batchList.length && timeToWaitToExecuteNextBatch > 0) {
+            console.log(`   └────── Waiting ${timeToWaitToExecuteNextBatch}ms before execute next batch.\n`);
+            await sleep(timeToWaitToExecuteNextBatch);
+        }
+        else
+            console.log('\n');
+    }
+    return runningTestIds;
+}
 
-                let assertions_failed = result.data.assertions_failed;
-                if(assertions_failed > 0) {
-                    // Dá o erro para parar a execução
-                    throw Error("ASSERTION FAILED");
-                } else {
-                    console.log("SUCESSO!");
+function triggerTest(testId) {
+    return new Promise((resolve) => {
+        axios.post(`https://api.runscope.com/radar/${testId}/trigger?runscope_environment=${environmentId}`)
+            .then((value) => {
+                const testRunId = value.data.data.runs[0].test_run_id;
+                const triggeredTestId = value.data.data.runs[0].test_id;
+                const testName = value.data.data.runs[0].test_name;
+                resolve({triggeredTestId, testRunId, testName});
+            }).catch(async reason => {
+                if(reason.response.status == 404) {// Not found
+                    throw Error(`Test not found,  testId: ${testId}`);
                 }
-            }
-        }
-        else if(error && res.statusCode == 404) {
-            //Faz uma nova tentativa em caso de 404 para evitar delays de resposta do runscope
-            if(verificationCounter.has(test_url)) {
-                const SECONDS_UNTIL_RETRY = 10000;
-
-                let numberOfAttempsMade = verificationCounter.get(test_url);
-                if(isNaN(numberOfAttempsMade)) {
-                    numberOfAttempsMade = 1;
+                else if(reason.response.status == 429) { // Too many requests
+                    let remainingRetries = 10;
+                    let retriedWithSuccess = false;
+                    while(retriedWithSuccess == false && remainingRetries > 0) {
+                        console.log(`Too many requests to Runscope API, waiting ${MINIMUM_INTERVAL_BETWEEN_BATCH_EXECUTION_IN_MS}ms before retry.`);
+                        await sleep(MINIMUM_INTERVAL_BETWEEN_BATCH_EXECUTION_IN_MS);
+                        triggerTest(testId)
+                            .then((retryReturnedData) => {
+                                retriedWithSuccess = true;
+                                remainingRetries = 0;
+                                resolve(retryReturnedData);
+                            });
+                    }
                 }
                 else {
-                    verificationCounter.set(test_url, ++numberOfAttempsMade) 
+                    throw Error(`An unexpected error occurred when test is triggered, testId: ${testId}, statusCode: ${reason.response.status}`);
                 }
-
-                if(numberOfAttempsMade < 3) {
-                    console.log(`Erro 404: Nova tentativa em ${SECONDS_UNTIL_RETRY} para teste: ${test_url}`);
-                    setTimeout(() => {
-                        verifyTest(test_url);
-                    }, SECONDS_UNTIL_RETRY);
-                }
-                else {
-                    throw Error(`Número máximo de tentativas atingidas: ${body}`);
-                }
-            }
-        } else {
-            throw Error(body);
-        }
+            });
     });
 }
 
-// Executa os requests iniciais paralelamente
-async.parallel(requestFunctions, (err, results) => {
-    console.log(results);
+function startVerificationOnTests(runningTestIds) {
+    let intervalLocked = false;
+    const intervalId = setInterval(async function() {
+        if(intervalLocked == false) {
+            intervalLocked = true;
+            
+            var notFinishedTests = runningTestIds.filter((value) => {
+                return !finishedTestIds.includes(value);
+            });
 
-    for (let i = 0; i < results.length; i++) {
-        let result = JSON.parse(results[i]);
+            if(notFinishedTests.length > 0)
+                console.log(`\nWaiting to finish ${notFinishedTests.length} tests of ${runningTestIds.length}\n`);
 
-        let bucketKey = result.data.runs[0].bucket_key;
-        let test_id = result.data.runs[0].test_id;
-        let test_run_id = result.data.runs[0].test_run_id;
-
-        let runsFail = result.data.runs_failed;
-        if (runsFail > 0) {
-            throw Error("Falha ao enviar teste id " + test_run_id);
+            for(let notFinishedTest of notFinishedTests) {
+                console.log(`Verifying test ${testNames[notFinishedTest.testId]}, result: https://www.runscope.com/radar/${bucketKey}/${notFinishedTest.triggeredTestId}/history/${notFinishedTest.testRunId}`);
+                await axios.get(`https://api.runscope.com/buckets/${bucketKey}/tests/${notFinishedTest.triggeredTestId}/results/${notFinishedTest.testRunId}`, {
+                    headers: {
+                        'Authorization': `Bearer ${runscopeApiKey}`
+                    }
+                }).then(value => {
+                    if(value.status == 200 && value.data.data.finished_at != null) {
+                        finishedTestIds.push(notFinishedTest);
+                        finishedTestResults[`${notFinishedTest.triggeredTestId}_${notFinishedTest.testRunId}`] = { testId: notFinishedTest.testId, runscopeData: value.data.data };
+                    }
+                }).catch(reason => {
+                    throw Error(`Error when reading test result for ${testNames[notFinishedTest.testId]} test, reason: ${JSON.stringify(reason)}`);
+                });
+            }
+            if(notFinishedTests.length == 0) {
+                clearInterval(intervalId);
+                printTestsExecutionResults();
+            }
+            intervalLocked = false;
         }
+    }, INTERVAL_BETWEEN_TEST_VERIFICATIONS_IN_MS);
+}
 
-        let test_url = 'https://api.runscope.com/buckets/' + bucketKey + '/tests/' + test_id + '/results/' + test_run_id;
-        console.log('Test Result URL: ' + test_url);
+function printTestsExecutionResults() {
+    let failedTests = 0;
+    console.log('\n');
 
-        setTimeout(function () {
-            verifyTest(test_url);
-        }, 10000);
+    for(let testResult in finishedTestResults) {
+        const testName = testNames[finishedTestResults[testResult].testId];
+
+        const testResultData = finishedTestResults[testResult].runscopeData;
+        const success = testResultData.assertions_failed == 0;
+        const statusIcon = success ? '✅' : '❌';
+        const statusMessage = success ? 'OK' : 'FAIL';
+        console.log(`[${statusMessage}] ${statusIcon} - ${testName} - ${testResultData.assertions_passed}/${testResultData.assertions_defined} assertions passed`);
+        if(success == false) {
+            failedTests ++;
+            console.log(`    └────── Runscope URL: https://www.runscope.com/radar/${testResultData.bucket_key}/${testResultData.test_id}/history/${testResultData.test_run_id}`);
+        }
     }
-});
 
-const status = (body) => {
-    return new Promise((resolve, reject) => {
-        resolve(body);
+    if(failedTests > 0) {
+        console.log(`❌ ERROR: ${failedTests} tests failed, ${finishedTestIds.length - failedTests} tests passed`);
+        process.exit(1);
+    }
+    console.log(`✅ SUCCESS: ${finishedTestIds.length} tests passed`);    
+}
+
+function splitArrayInPages(elements, pageSize = 8) {
+    var result = [];
+    while (elements.length) {
+        result.push(elements.splice(0, pageSize));
+    }
+    return result;
+}
+
+function arrayMapToObject(object, filterFunction) {
+    let results = {};
+    return Object.keys(object).reduce(function(result, key) {
+        if(filterFunction(key)) {
+            results[key] = object[key];
+            return results;
+        }
+    }, {});
+}
+
+function sleep(ms) {
+    return new Promise(resolve => {
+        setTimeout(resolve, ms);
     });
-};
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,355 +4,76 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-      "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      }
-    },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
-    "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
-    "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-    },
-    "mime-db": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
-    },
-    "mime-types": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-      "requires": {
-        "mime-db": "1.40.0"
-      }
-    },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
-    "psl": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
-    },
-    "punycode": {
+    "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-    },
-    "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "follow-redirects": "1.5.10"
       }
     },
-    "safe-buffer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
     },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+    "columnify": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+      "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "strip-ansi": "^3.0.0",
+        "wcwidth": "^1.0.0"
       }
     },
-    "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        }
+        "ms": "2.0.0"
       }
     },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "clone": "^1.0.2"
       }
     },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
-    "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
-        "punycode": "^2.1.0"
+        "debug": "=3.1.0"
       }
     },
-    "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "requires": {
+        "defaults": "^1.0.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Guilherme Nunes & Diego Wagner",
   "license": "MIT",
   "dependencies": {
-    "async": "^2.6.0",
-    "request": "^2.86.0"
+    "axios": "^0.19.2",
+    "columnify": "^1.5.4"
   }
 }


### PR DESCRIPTION
Foi alterado todo o script de execução para que fique mais seguro e que também mostre logs mais úteis.
Também foi adicionado a feature de listar os testes pela api do Runscope ignorando os testes cujo o nome inicie em [IGNORED]

Para selecionar entre os testes que estão na API do runscope é simples:

- Para obter a lista dos testes a serem rodados da API do runscope basta não informar nenhum teste pelo argumento -tests.

- Para obter a lista dos testes a serem rodados via argumento, basta informar o argumento -tests seguido pelos testes que serão executados (Compatível com a abordagem anterior)